### PR TITLE
Fix wrong script name in docs and usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Detect registered typo-squatting domains for a list of input domains, and check 
 2. **Run the script:**
 
    ```sh
-   python typosquat_whois_check.py domains.txt typosquat_results.txt
+   python typewhat.py domains.txt typosquat_results.txt
    ```
 
    * The first argument is your input file.

--- a/typewhat.py
+++ b/typewhat.py
@@ -116,6 +116,6 @@ def main(input_filename, output_filename):
 if __name__ == "__main__":
     import sys
     if len(sys.argv) != 3:
-        print("Usage: python typosquat_whois_check.py <input_file.txt> <output_file.txt>")
+        print("Usage: python typewhat.py <input_file.txt> <output_file.txt>")
         exit(1)
     main(sys.argv[1], sys.argv[2])


### PR DESCRIPTION
## Summary
- fix usage message to reference `typewhat.py`
- update README to call the correct script

## Testing
- `python -m py_compile typewhat.py`

------
https://chatgpt.com/codex/tasks/task_e_6877cef3d5b083208e32e3e2126bb20f