### PR TITLE
Check for missing OpenAI key

### DIFF
--- a/typewhat.py
+++ b/typewhat.py
@@ -14,6 +14,10 @@ OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-4o")
 OPENAI_TIMEOUT = int(os.getenv("OPENAI_TIMEOUT", 60))
 WHOIS_DELAY = float(os.getenv("WHOIS_DELAY", 1.5))  # seconds between WHOIS queries
 
+if not OPENAI_API_KEY:
+    print("Error: OPENAI_API_KEY not set")
+    exit(1)
+
 openai.api_key = OPENAI_API_KEY
 
 def generate_typos(domain, typo_count):


### PR DESCRIPTION
## Summary
- exit early when `OPENAI_API_KEY` env variable is not provided

## Testing
- `python -m py_compile typewhat.py`


------
https://chatgpt.com/codex/tasks/task_e_6877d371708083209bc589ccf5ef69e9